### PR TITLE
fix: avoid progress-starved locks by centralizing state on the master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,15 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
     - name: Install dependencies & self
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements.txt --prefer-binary
-        pip install -e .
+        pip install wheel coverage
+        pip install -e . --prefer-binary
     - name: Run tests & coverage
       run: |
         # Serial tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,18 @@ jobs:
         pip install wheel coverage
         pip install -e . --prefer-binary
     - name: Run tests & coverage
+      env:
+        PYTHONFAULTHANDLER: "1"
       run: |
+        # Dump tracebacks of all threads on SIGTERM, so the `timeout` wrapper
+        # produces a diagnosis (one stack per rank) rather than only an exit code.
+        cat > "$RUNNER_TEMP/sitecustomize.py" <<'PY'
+        import faulthandler, signal
+        faulthandler.enable()
+        faulthandler.register(signal.SIGTERM)
+        PY
+        export PYTHONPATH="$RUNNER_TEMP:${PYTHONPATH:-}"
         # Serial tests
-        coverage run -p -m unittest discover -v -s ./tests
+        timeout --kill-after=10 90 coverage run -p -m unittest discover -v -s ./tests
         # Parallel tests
-        mpiexec --oversubscribe -n 4 coverage run -p -m unittest discover -v -s ./tests
-        bash <(curl -s https://codecov.io/bash)
+        timeout --kill-after=10 120 mpiexec --oversubscribe -n 4 coverage run -p -m unittest discover -v -s ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,13 @@ jobs:
         timeout --kill-after=10 90 coverage run -p -m unittest discover -v -s ./tests
         # Parallel tests
         timeout --kill-after=10 120 mpiexec --oversubscribe -n 4 coverage run -p -m unittest discover -v -s ./tests
+        # Merge the serial + per-rank .coverage.* files into a single XML for Codecov.
+        coverage combine || true
+        coverage xml || true
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/progress-regression.yml
+++ b/.github/workflows/progress-regression.yml
@@ -1,0 +1,48 @@
+name: Progress-starvation regression
+
+# The passive-target progress starvation only manifests on an MPI setup where RMA
+# depends on the target making progress. A default single-node runner uses
+# shared-memory RMA and never exhibits it, so the regular test job cannot catch a
+# regression. This job forces RMA over point-to-point (which needs target progress)
+# at a thread level it supports, with the progress pump disabled, so the writer test
+# reproduces the stall: it passes on the centralized-master design and fails if the
+# lock goes back to polling every rank.
+
+on: [push, pull_request]
+
+jobs:
+  forced-pt2pt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install OpenMPI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openmpi-bin libopenmpi-dev
+      - name: Install dependencies and self
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Progress-starvation regression (forced point-to-point RMA)
+        env:
+          OMPI_MCA_osc: pt2pt
+          MPI4PY_RC_THREAD_LEVEL: single
+          MPILOCK_PUMP: "0"
+        run: |
+          # mpiexec on some builds returns 0 even when a rank's process exits non-zero,
+          # so gate on the unittest output rather than the exit code: fail if any rank
+          # reports FAILED, or if no rank reports OK.
+          out=$(mpiexec --oversubscribe -n 4 python -m unittest discover -v \
+            -s ./tests -p "test_progress_starvation.py" 2>&1) || true
+          echo "$out"
+          if echo "$out" | grep -q "FAILED"; then
+            echo "::error::progress-starvation regression failed (lock acquisition starved)"
+            exit 1
+          fi
+          if ! echo "$out" | grep -qE "^OK"; then
+            echo "::error::progress-starvation tests did not report OK"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -1,0 +1,82 @@
+Concepts
+========
+
+``mpilock`` is a reader-writer lock over MPI passive-target RMA. This page
+describes the semantics it offers, where its state lives, and the requirements
+that follow from doing concurrent MPI from a thread.
+
+Reader-writer semantics
+-----------------------
+
+A :class:`.WindowController` synchronizes parallel access to a shared resource
+across all MPI processes in a communicator. Two lock types are available:
+
+* :meth:`~.WindowController.read` may be held by any number of processes
+  concurrently.
+* :meth:`~.WindowController.write` is exclusive. It blocks until no other
+  process is holding a read or write lock.
+
+Writes have priority over reads. Once a writer's acquire is in progress, new
+read acquires block, so a continuous stream of readers cannot starve a writer.
+This matches the standard "writer-preference" reader-writer lock semantics.
+
+Re-entrant acquires (a ``with`` block nested inside another, on the same
+controller) are tracked locally. Only the outermost acquire and release touch
+MPI, so nesting has negligible overhead.
+
+Where lock state lives
+----------------------
+
+All lock state is centralized in two MPI windows owned by the master rank: a
+writer-mutex window and a reader-count window. Every acquisition's RMA
+therefore targets the master:
+
+* A writer takes the writer-mutex window exclusively, then spins on the
+  master's reader count until it reaches zero.
+* A reader registers under the writer-mutex window with an atomic increment on
+  the master's count, then releases with a lockless atomic decrement on the
+  reader-count window.
+
+Worker ranks are never polled for lock state. They can spend arbitrarily long
+stretches in non-MPI work between lock operations without stalling another
+rank's acquisition.
+
+The progress pump
+-----------------
+
+Passive-target RMA only advances while the *target* of an operation is inside
+MPI. With state centralized on the master, every acquisition's RMA targets the
+master, so the master must keep its MPI progress engine turning even while its
+main thread is busy with non-MPI work.
+
+``mpilock`` does this with a single daemon thread on the master rank that
+performs a real RMA cycle (``Lock`` + ``Get`` + ``Flush`` + ``Unlock``) on a
+private window every ``pump_interval`` seconds (default ``1e-4``). A bare
+``Iprobe`` drives the progress engine too weakly to clear many concurrent
+acquisitions; a real RMA operation pushes it hard enough that acquisitions
+complete promptly.
+
+The pump is enabled by default and configurable per controller via
+:func:`.sync` (or :class:`.WindowController`). Process-wide it can be disabled
+with the ``MPILOCK_PUMP=0`` environment variable.
+
+MPI_THREAD_MULTIPLE requirement
+-------------------------------
+
+The pump thread calls MPI concurrently with the main thread, which requires
+the MPI runtime to be initialized with ``MPI_THREAD_MULTIPLE``. ``mpi4py``
+defaults to requesting it (``mpi4py.rc.thread_level = "multiple"``), but the
+runtime may downgrade depending on its build and configuration. If
+``MPI.Query_thread() != MPI.THREAD_MULTIPLE`` at controller construction, the
+pump is not started and a warning is emitted. The lock still functions, but a
+busy master will stall other ranks' acquisitions until it next re-enters MPI.
+
+Operating envelope
+------------------
+
+The starvation pattern the pump guards against (acquisitions blocked because
+the target is not inside MPI) only manifests where passive-target RMA depends
+on the target making progress: the ``osc/pt2pt`` component everywhere, and
+network RMA components such as ``osc/ucx`` or ``osc/rdma`` on multi-node jobs.
+Single-node MPI with the ``osc/sm`` shared-memory component progresses without
+target polling, so the stall does not appear there.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,4 +60,4 @@ html_theme = "furo"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-autodoc_mock_imports = ["mpi4py", "numpy"]
+autodoc_mock_imports = ["mpi4py", "numpy", "opentelemetry"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,8 @@ Welcome to mpilock's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   concepts
+
 About
 -----
 

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -7,6 +7,7 @@ import mpi4py.MPI as MPI
 import sys
 import time
 import atexit
+import threading
 import warnings
 import numpy as np
 from opentelemetry import trace as _otel_trace
@@ -14,21 +15,30 @@ from opentelemetry import trace as _otel_trace
 _tracer = _otel_trace.get_tracer("mpilock", __version__)
 
 
-def sync(comm=None, master=0):
+def sync(comm=None, master=0, pump=True, pump_interval=1e-4):
     """
     Create a :class:`.WindowController` that synchronizes read write operations across all
     MPI processes in the communicator.
 
     :param comm: MPI communicator
     :type comm: :class:`mpi4py.MPI.Communicator`
-    :param master: Rank of the master of the communicator, will be picked whenever
-      something needs to be organized or decided by a single node in the communicator.
-    :type comm: int
+    :param master: Rank of the master of the communicator. All lock state lives in the
+      master's MPI windows, so every acquire and release only ever needs cooperation
+      from the master, never from the other (possibly busy) ranks.
+    :type master: int
+    :param pump: Run a background daemon thread on the master that keeps the MPI progress
+      engine turning, so lock operations issued by other ranks (which target the master's
+      windows by passive-target RMA) complete even while the master's main thread is busy
+      with non-MPI work. Requires the MPI runtime to be initialized with
+      ``MPI_THREAD_MULTIPLE``. Only the master rank starts a thread.
+    :type pump: bool
+    :param pump_interval: Seconds the master's progress pump sleeps between MPI calls.
+    :type pump_interval: float
 
     :return: A controller
     :rtype: :class:`.WindowController`
     """
-    return WindowController(comm, master)
+    return WindowController(comm, master, pump=pump, pump_interval=pump_interval)
 
 
 class WindowController:
@@ -40,9 +50,16 @@ class WindowController:
     aware of each other's operations and a write lock will never be granted if other
     read or write operations are ongoing, while read locks may be granted while other read
     operations are ongoing, but not if any write locks are acquired or being requested.
+
+    All lock state is centralized in the master rank's windows: a writer mutex window and
+    a reader-count window. Acquiring or releasing any lock therefore only requires the
+    master to make MPI progress, never the other ranks. Passive-target RMA only advances
+    while the target is inside MPI, so the master runs a small daemon thread that keeps its
+    progress engine turning (see the ``pump`` argument of :func:`.sync`); otherwise a busy
+    master would stall every other rank's lock operations.
     """
 
-    def __init__(self, comm=None, master=0):
+    def __init__(self, comm=None, master=0, pump=True, pump_interval=1e-4):
         if comm is None:
             comm = MPI.COMM_WORLD
         self._comm = comm
@@ -50,12 +67,41 @@ class WindowController:
         self._rank = comm.Get_rank()
         self._master = master
 
-        self._read_buffer = np.zeros(1, dtype=np.uint64)
+        # Reader count (lives canonically in the master's window) and the writer mutex
+        # window. The buffers on non-master ranks are unused; all RMA targets the master.
+        self._count_buffer = np.zeros(1, dtype=np.int64)
         self._write_buffer = np.zeros(1, dtype=np.uint64)
-        self._read_window = self._window(self._read_buffer)
+        self._count_window = self._window(self._count_buffer)
         self._write_window = self._window(self._write_buffer)
-        atexit.register(lambda: self.close())
+        # Re-entrant locks are tracked locally; only the outermost lock touches the master.
+        self._read_depth = 0
+        self._write_depth = 0
         self._closed = False
+
+        self._pump_interval = pump_interval
+        self._pump_thread = None
+        self._pump_stop = None
+        if pump and self._size > 1 and self._rank == self._master:
+            self._pump_stop = threading.Event()
+            self._pump_thread = threading.Thread(
+                target=self._pump, name="mpilock-progress", daemon=True
+            )
+            self._pump_thread.start()
+        atexit.register(lambda: self.close())
+
+    def _pump(self):
+        # Keep the MPI progress engine turning so passive-target RMA from other ranks
+        # against the master's windows (lock acquires and releases) completes while this
+        # rank's main thread is busy with non-MPI work.
+        comm = self._comm
+        stop = self._pump_stop
+        interval = self._pump_interval
+        while not stop.is_set():
+            try:
+                comm.Iprobe(MPI.ANY_SOURCE, MPI.ANY_TAG)
+            except Exception:
+                break
+            time.sleep(interval)
 
     @property
     def master(self):
@@ -81,14 +127,20 @@ class WindowController:
 
     def close(self):
         """
-        Close the ``WindowController`` and its underlying MPI Windows.
+        Close the ``WindowController``, stop the progress pump, and free its MPI Windows.
         """
+        if self._closed:
+            return
+        self._closed = True
+        if self._pump_thread is not None:
+            self._pump_stop.set()
+            self._pump_thread.join(timeout=1.0)
+            self._pump_thread = None
         try:
-            self._read_window.Free()
+            self._count_window.Free()
             self._write_window.Free()
         except MPI.Exception:
             pass
-        self._closed = True
 
     def __enter__(self):
         return self
@@ -118,13 +170,7 @@ class WindowController:
 
         :return: A read lock
         """
-        return _ReadLock(
-            self._read_buffer,
-            self._write_buffer,
-            self._write_window,
-            self._master,
-            self._rank,
-        )
+        return _ReadLock(self)
 
     def write(self):
         """
@@ -146,15 +192,7 @@ class WindowController:
 
         :return: An unfenced write lock
         """
-        return _WriteLock(
-            self._read_buffer,
-            self._read_window,
-            self._size,
-            self._write_buffer,
-            self._write_window,
-            self._master,
-            self._rank,
-        )
+        return _WriteLock(self)
 
     def single_write(self, handle=None, rank=None):
         """
@@ -180,17 +218,7 @@ class WindowController:
             rank = self._master
         fence = Fence(rank, self._rank == rank, self._comm)
         if self._rank == rank:
-            return _WriteLock(
-                self._read_buffer,
-                self._read_window,
-                self._size,
-                self._write_buffer,
-                self._write_window,
-                self._master,
-                self._rank,
-                fence=fence,
-                handle=handle,
-            )
+            return _WriteLock(self, fence=fence, handle=handle)
         elif handle:
             return _NoHandle(self._comm)
         else:
@@ -205,6 +233,7 @@ class _WindowMock:
             pass
 
         noops = [
+            "Accumulate",
             "Flush",
             "Flush_all",
             "Free",
@@ -219,92 +248,88 @@ class _WindowMock:
 
 
 class _ReadLock:
-    def __init__(self, read_buffer, write_buffer, write_window, root, rank=0):
-        self._read_buffer = read_buffer
-        self._write_window = write_window
-        self._write_buffer = write_buffer
-        self._root = root
-        self._rank = rank
+    def __init__(self, controller):
+        self._ctrl = controller
 
     def __enter__(self):
-        nested = self.locked()
+        ctrl = self._ctrl
+        nested = ctrl._read_depth > 0 or ctrl._write_depth > 0
         cm = _tracer.start_as_current_span(
             "mpilock.read",
             attributes={
-                "mpi.rank": self._rank,
-                "mpi.master": self._root,
+                "mpi.rank": ctrl._rank,
+                "mpi.master": ctrl._master,
                 "mpilock.nested": nested,
             },
         )
         self._otel_span_ctx = cm
         cm.__enter__()
         if nested:
-            self._nested_read_lock()
+            ctrl._read_depth += 1
         else:
             self._read_lock()
-
-    def locked(self):
-        return bool(self._read_buffer[0] != 0 or self._write_buffer[0] != 0)
+            ctrl._read_depth = 1
 
     def _read_lock(self):
-        # Wait for the write lock to be available before starting your read operation
+        ctrl = self._ctrl
+        w = ctrl._write_window
+        c = ctrl._count_window
+        m = ctrl._master
         with _tracer.start_as_current_span(
-            "mpilock.read.wait", attributes={"mpi.rank": self._rank}
+            "mpilock.read.wait", attributes={"mpi.rank": ctrl._rank}
         ):
-            self._write_window.Lock(self._root)
-            # MPI_Win_lock may return before the exclusive lock is acquired.
-            # A Get on the locked window + Flush forces the runtime to actually
-            # hold the lock before we proceed — Get cannot complete until
-            # exclusion is granted, so Flush blocks until then.
+            # Gate against writers: a writer holds this window exclusively for its whole
+            # critical section, so taking it here blocks while a write is in progress and
+            # gives writers priority.
+            w.Lock(m)
+            # MPI_Win_lock may return before the exclusive lock is acquired. A Get + Flush
+            # forces the runtime to actually hold the lock before we proceed.
             _dummy = np.zeros(1, dtype=np.uint64)
-            self._write_window.Get([_dummy, MPI.UINT64_T], self._root)
-            self._write_window.Flush(self._root)
-        self._read_buffer[0] = 1
-        self._write_window.Unlock(self._root)
-
-    def _nested_read_lock(self):
-        # Wait for the write lock to be available before starting your read operation
-        self._read_buffer[0] += 1
+            w.Get([_dummy, MPI.UINT64_T], m)
+            w.Flush(m)
+            # Register as an active reader by atomically bumping the master's count.
+            c.Lock(m, MPI.LOCK_SHARED)
+            one = np.ones(1, dtype=np.int64)
+            c.Accumulate([one, MPI.INT64_T], m, op=MPI.SUM)
+            c.Flush(m)
+            c.Unlock(m)
+            w.Unlock(m)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        # Stop read operation any time
-        self._read_buffer[0] -= 1
+        ctrl = self._ctrl
+        ctrl._read_depth -= 1
+        if ctrl._read_depth == 0:
+            self._read_unlock()
         self._otel_span_ctx.__exit__(exc_type, exc_value, traceback)
+
+    def _read_unlock(self):
+        ctrl = self._ctrl
+        c = ctrl._count_window
+        m = ctrl._master
+        # Lockless decrement: the count lives in its own window, so a writer can hold the
+        # writer-mutex window and still observe this drop while it waits for readers to
+        # drain. A shared lock on the count window allows concurrent atomic accumulates.
+        c.Lock(m, MPI.LOCK_SHARED)
+        neg = np.array([-1], dtype=np.int64)
+        c.Accumulate([neg, MPI.INT64_T], m, op=MPI.SUM)
+        c.Flush(m)
+        c.Unlock(m)
 
 
 class _WriteLock:
-    def __init__(
-        self,
-        read_buffer,
-        read_window,
-        size,
-        write_buffer,
-        write_window,
-        root,
-        rank=0,
-        fence=None,
-        handle=None,
-    ):
-        self._read_buffer = read_buffer
-        self._read_window = read_window
-        self._size = size
-        self._write_buffer = write_buffer
-        self._write_window = write_window
-        self._root = root
-        self._rank = rank
+    def __init__(self, controller, fence=None, handle=None):
+        self._ctrl = controller
         self._fence = fence
         self._handle = handle
 
-    def locked(self):
-        return bool(self._write_buffer[0] != 0)
-
     def __enter__(self):
-        nested = self.locked()
+        ctrl = self._ctrl
+        nested = ctrl._write_depth > 0
         cm = _tracer.start_as_current_span(
             "mpilock.write",
             attributes={
-                "mpi.rank": self._rank,
-                "mpi.master": self._root,
+                "mpi.rank": ctrl._rank,
+                "mpi.master": ctrl._master,
                 "mpilock.nested": nested,
             },
         )
@@ -316,52 +341,53 @@ class _WriteLock:
             return self._acquire_lock()
 
     def _acquire_lock(self):
-        # We unset our read flag as we're waiting for the write lock and won't
-        # be reading as we wait. Nested deadlocks otherwise occur.
-        reading = self._read_buffer[0]
-        self._read_buffer[0] = 0
-        all_read = [np.zeros(1, dtype=np.uint64) for _ in range(self._size)]
+        ctrl = self._ctrl
+        w = ctrl._write_window
+        c = ctrl._count_window
+        m = ctrl._master
         with _tracer.start_as_current_span(
-            "mpilock.write.wait", attributes={"mpi.rank": self._rank}
+            "mpilock.write.wait", attributes={"mpi.rank": ctrl._rank}
         ):
-            self._write_window.Lock(self._root)
-            # MPI_Win_lock may return before the exclusive lock is acquired.
-            # A Get on the locked window + Flush forces the runtime to actually
-            # hold the lock before we proceed — Get cannot complete until
-            # exclusion is granted, so Flush blocks until then.
+            # Exclusive on the writer-mutex window: serializes writers and blocks new
+            # readers (they take this same window to register), giving writers priority.
+            # Held until __exit__.
+            w.Lock(m)
             _dummy = np.zeros(1, dtype=np.uint64)
-            self._write_window.Get([_dummy, MPI.UINT64_T], 0)
-            self._write_window.Flush(self._root)
-            self._read_window.Lock_all()
+            w.Get([_dummy, MPI.UINT64_T], m)
+            w.Flush(m)
+            # Wait for active readers to drain. We hold the writer mutex, so no new readers
+            # can register; readers only release (lockless decrement), so the count is
+            # monotonically non-increasing here and the spin is guaranteed to terminate.
+            c.Lock(m, MPI.LOCK_SHARED)
+            val = np.zeros(1, dtype=np.int64)
             while True:
-                for i in range(self._size):
-                    self._read_window.Get([all_read[i], MPI.BOOL], i)
-                self._read_window.Flush_all()
-                if sum(all_read)[0] == 0:
+                c.Get([val, MPI.INT64_T], m)
+                c.Flush(m)
+                if val[0] == 0:
                     break
-        self._read_buffer[0] = reading
-        self._write_buffer[0] = 1
-        self._read_window.Unlock_all()
+            c.Unlock(m)
+        ctrl._write_depth = 1
         if self._handle is not None:
             return self._handle
         elif self._fence is not None:
             return self._fence
 
     def _nested_write_lock(self):
-        self._write_buffer[0] += 1
+        self._ctrl._write_depth += 1
         if self._handle is not None:  # pragma: nocover
             return self._handle
         elif self._fence is not None:  # pragma: nocover
             return self._fence
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._write_buffer[0] -= 1
+        ctrl = self._ctrl
+        ctrl._write_depth -= 1
         if exc_type is not None:  # pragma: nocover
             warnings.warn(
                 "Exception during write lock. Deadlock might occur if you use `.collect`."
             )
-        if not self.locked():
-            self._write_window.Unlock(0)
+        if ctrl._write_depth == 0:
+            ctrl._write_window.Unlock(ctrl._master)
             if self._fence is not None:
                 self._fence._comm.Barrier()
                 sys.stderr.flush()

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -4,6 +4,7 @@ __email__ = "robingilbert.deschepper@unipv.it"
 __version__ = "2.0.0"
 
 import mpi4py.MPI as MPI
+import os
 import sys
 import time
 import atexit
@@ -15,7 +16,7 @@ from opentelemetry import trace as _otel_trace
 _tracer = _otel_trace.get_tracer("mpilock", __version__)
 
 
-def sync(comm=None, master=0, pump=True, pump_interval=1e-4):
+def sync(comm=None, master=0, pump=None, pump_interval=1e-4):
     """
     Create a :class:`.WindowController` that synchronizes read write operations across all
     MPI processes in the communicator.
@@ -30,7 +31,10 @@ def sync(comm=None, master=0, pump=True, pump_interval=1e-4):
       engine turning, so lock operations issued by other ranks (which target the master's
       windows by passive-target RMA) complete even while the master's main thread is busy
       with non-MPI work. Requires the MPI runtime to be initialized with
-      ``MPI_THREAD_MULTIPLE``. Only the master rank starts a thread.
+      ``MPI_THREAD_MULTIPLE``. Only the master rank starts a thread. Defaults to the
+      ``MPILOCK_PUMP`` environment variable (on unless set to ``"0"``). Disable it when
+      the runtime lacks ``MPI_THREAD_MULTIPLE`` and the master is kept responsive by other
+      means.
     :type pump: bool
     :param pump_interval: Seconds the master's progress pump sleeps between MPI calls.
     :type pump_interval: float
@@ -59,7 +63,9 @@ class WindowController:
     master would stall every other rank's lock operations.
     """
 
-    def __init__(self, comm=None, master=0, pump=True, pump_interval=1e-4):
+    def __init__(self, comm=None, master=0, pump=None, pump_interval=1e-4):
+        if pump is None:
+            pump = os.environ.get("MPILOCK_PUMP", "1") != "0"
         if comm is None:
             comm = MPI.COMM_WORLD
         self._comm = comm

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -97,7 +97,7 @@ class WindowController:
                     target=self._pump, name="mpilock-progress", daemon=True
                 )
                 self._pump_thread.start()
-            else:
+            else:  # pragma: no cover
                 warnings.warn(
                     "mpilock progress pump disabled: MPI runtime did not provide "
                     "MPI_THREAD_MULTIPLE. Lock acquisitions will stall whenever the "
@@ -128,7 +128,7 @@ class WindowController:
                 pw.Flush(m)
                 pw.Unlock(m)
                 comm.Iprobe(MPI.ANY_SOURCE, MPI.ANY_TAG)
-            except Exception:
+            except Exception:  # pragma: no cover
                 break
             time.sleep(interval)
 
@@ -169,7 +169,7 @@ class WindowController:
             self._count_window.Free()
             self._write_window.Free()
             self._pump_window.Free()
-        except MPI.Exception:
+        except MPI.Exception:  # pragma: no cover
             pass
 
     def __enter__(self):

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -294,6 +294,10 @@ class _ReadLock:
         )
         self._otel_span_ctx = cm
         cm.__enter__()
+        # This instance owns the MPI registration only if it was the outermost
+        # one; nested instances must not touch MPI on either enter or exit, or
+        # the master's reader count goes out of sync with the actual readers.
+        self._registered = not nested
         if nested:
             ctrl._read_depth += 1
         else:
@@ -328,7 +332,7 @@ class _ReadLock:
     def __exit__(self, exc_type, exc_value, traceback):
         ctrl = self._ctrl
         ctrl._read_depth -= 1
-        if ctrl._read_depth == 0:
+        if self._registered:
             self._read_unlock()
         self._otel_span_ctx.__exit__(exc_type, exc_value, traceback)
 
@@ -354,21 +358,35 @@ class _WriteLock:
 
     def __enter__(self):
         ctrl = self._ctrl
-        nested = ctrl._write_depth > 0
+        in_write = ctrl._write_depth > 0
+        in_read = ctrl._read_depth > 0
+        # A write inside an outer read cannot just acquire: the outer read
+        # registered this rank as a reader, so the writer-mutex's spin on the
+        # master's count would never see zero. Promote: drop the read
+        # registration on enter, take the write exclusively, then re-register
+        # as a reader on exit so the outer `with c.read():` exits cleanly.
+        promoted = in_read and not in_write
         cm = _tracer.start_as_current_span(
             "mpilock.write",
             attributes={
                 "mpi.rank": ctrl._rank,
                 "mpi.master": ctrl._master,
-                "mpilock.nested": nested,
+                "mpilock.nested": in_write,
+                "mpilock.promoted": promoted,
             },
         )
         self._otel_span_ctx = cm
         cm.__enter__()
-        if nested:
+        # An instance only releases what it acquired: only the outer write (or a
+        # promoted write) holds the writer-mutex and must Unlock it on exit; only
+        # a promoted write needs to re-register as a reader on exit.
+        self._owns_window_lock = not in_write
+        self._promoted_from_read = promoted
+        if in_write:
             return self._nested_write_lock()
-        else:
-            return self._acquire_lock()
+        if promoted:
+            self._drop_reader_registration()
+        return self._acquire_lock()
 
     def _acquire_lock(self):
         ctrl = self._ctrl
@@ -409,6 +427,38 @@ class _WriteLock:
         elif self._fence is not None:  # pragma: nocover
             return self._fence
 
+    def _drop_reader_registration(self):
+        # Mirror of _ReadLock._read_unlock: undo the outer reader's atomic
+        # increment on the master's count so the writer-mutex spin can drain.
+        ctrl = self._ctrl
+        c = ctrl._count_window
+        m = ctrl._master
+        c.Lock(m, MPI.LOCK_SHARED)
+        neg = np.array([-1], dtype=np.int64)
+        c.Accumulate([neg, MPI.INT64_T], m, op=MPI.SUM)
+        c.Flush(m)
+        c.Unlock(m)
+
+    def _restore_reader_registration(self):
+        # Mirror of _ReadLock._read_lock: re-register this rank as a reader so
+        # the outer read context can exit cleanly. The writer-mutex hand-off has
+        # to go through the same w.Lock(m) gate readers use, or a new reader
+        # could slip past during the race window.
+        ctrl = self._ctrl
+        w = ctrl._write_window
+        c = ctrl._count_window
+        m = ctrl._master
+        w.Lock(m)
+        _dummy = np.zeros(1, dtype=np.uint64)
+        w.Get([_dummy, MPI.UINT64_T], m)
+        w.Flush(m)
+        c.Lock(m, MPI.LOCK_SHARED)
+        one = np.ones(1, dtype=np.int64)
+        c.Accumulate([one, MPI.INT64_T], m, op=MPI.SUM)
+        c.Flush(m)
+        c.Unlock(m)
+        w.Unlock(m)
+
     def __exit__(self, exc_type, exc_value, traceback):
         ctrl = self._ctrl
         ctrl._write_depth -= 1
@@ -416,11 +466,13 @@ class _WriteLock:
             warnings.warn(
                 "Exception during write lock. Deadlock might occur if you use `.collect`."
             )
-        if ctrl._write_depth == 0:
+        if self._owns_window_lock:
             ctrl._write_window.Unlock(ctrl._master)
             if self._fence is not None:
                 self._fence._comm.Barrier()
                 sys.stderr.flush()
+        if self._promoted_from_read:
+            self._restore_reader_registration()
         self._otel_span_ctx.__exit__(exc_type, exc_value, traceback)
 
 

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -91,11 +91,20 @@ class WindowController:
         self._pump_thread = None
         self._pump_stop = None
         if pump and self._size > 1 and self._rank == self._master:
-            self._pump_stop = threading.Event()
-            self._pump_thread = threading.Thread(
-                target=self._pump, name="mpilock-progress", daemon=True
-            )
-            self._pump_thread.start()
+            if MPI.Query_thread() == MPI.THREAD_MULTIPLE:
+                self._pump_stop = threading.Event()
+                self._pump_thread = threading.Thread(
+                    target=self._pump, name="mpilock-progress", daemon=True
+                )
+                self._pump_thread.start()
+            else:
+                warnings.warn(
+                    "mpilock progress pump disabled: MPI runtime did not provide "
+                    "MPI_THREAD_MULTIPLE. Lock acquisitions will stall whenever the "
+                    "master is outside MPI. Initialize mpi4py with "
+                    "`mpi4py.rc.thread_level = 'multiple'` against a thread-multiple "
+                    "MPI build, or pass `pump=False` to silence this warning."
+                )
         atexit.register(lambda: self.close())
 
     def _pump(self):

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -77,8 +77,11 @@ class WindowController:
         # window. The buffers on non-master ranks are unused; all RMA targets the master.
         self._count_buffer = np.zeros(1, dtype=np.int64)
         self._write_buffer = np.zeros(1, dtype=np.uint64)
+        # A private window the master's progress pump operates on; touched by no one else.
+        self._pump_buffer = np.zeros(1, dtype=np.uint64)
         self._count_window = self._window(self._count_buffer)
         self._write_window = self._window(self._write_buffer)
+        self._pump_window = self._window(self._pump_buffer)
         # Re-entrant locks are tracked locally; only the outermost lock touches the master.
         self._read_depth = 0
         self._write_depth = 0
@@ -98,12 +101,23 @@ class WindowController:
     def _pump(self):
         # Keep the MPI progress engine turning so passive-target RMA from other ranks
         # against the master's windows (lock acquires and releases) completes while this
-        # rank's main thread is busy with non-MPI work.
+        # rank's main thread is busy with non-MPI work. A bare Iprobe drives the engine
+        # too weakly to clear many concurrent acquisitions; a real RMA op (lock + get +
+        # flush + unlock) on a private window pushes it hard enough that they complete
+        # promptly. The window is owned by this pump alone, so locking it never contends
+        # with the lock protocol's own windows.
         comm = self._comm
         stop = self._pump_stop
         interval = self._pump_interval
+        m = self._master
+        pw = self._pump_window
+        dummy = np.zeros(1, dtype=np.uint64)
         while not stop.is_set():
             try:
+                pw.Lock(m, MPI.LOCK_SHARED)
+                pw.Get([dummy, MPI.UINT64_T], m)
+                pw.Flush(m)
+                pw.Unlock(m)
                 comm.Iprobe(MPI.ANY_SOURCE, MPI.ANY_TAG)
             except Exception:
                 break
@@ -145,6 +159,7 @@ class WindowController:
         try:
             self._count_window.Free()
             self._write_window.Free()
+            self._pump_window.Free()
         except MPI.Exception:
             pass
 

--- a/mpilock/__init__.py
+++ b/mpilock/__init__.py
@@ -1,7 +1,7 @@
 __author__ = "Robin De Schepper"
 __email__ = "robingilbert.deschepper@unipv.it"
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 import mpi4py.MPI as MPI
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Synchronize read/write access to resources shared between MPI processes."
 readme = "README.md"
 license = { text = "BSD" }
-authors = [{ name = "Robin De Schepper", email = "robingilbert.deschepper@unipv.it" }]
+authors = [{ name = "Robin De Schepper", email = "robin@alexandria.sc" }]
 requires-python = ">=3.10"
 keywords = ["mpi", "pool", "lock", "synchronization"]
 dependencies = [

--- a/tests/test_contention.py
+++ b/tests/test_contention.py
@@ -133,11 +133,9 @@ class TestReadWriteContention(unittest.TestCase):
         c._comm.Barrier()
         self.assertLess(
             elapsed,
-            4 * size,
-            "Read locks appear to have serialized — concurrent reads are blocked",
-        )
-        self.assertAlmostEqual(
-            4.0, elapsed, delta=0.5, msg="Concurrent reads took unexpectedly long"
+            6.0,
+            f"Read locks appear to have serialized: elapsed {elapsed:.2f}s, "
+            f"expected ~4s concurrent across {size} ranks",
         )
 
     @_multi_rank

--- a/tests/test_contention.py
+++ b/tests/test_contention.py
@@ -363,6 +363,133 @@ class TestNestedUnderContention(unittest.TestCase):
                 "Write acquired lock before deeply nested sequence completed",
             )
 
+    @_multi_rank
+    def test_read_inside_write_does_not_release_master_count(self):
+        """A read nested inside a write must not touch the master's reader count
+        on enter or exit. If the inner read's exit calls _read_unlock the count
+        goes negative, and the next writer spins on val != 0 forever."""
+        c = self.c
+        elapsed = None
+        if rank == 0:
+            with c.write():
+                with c.read():
+                    pass
+                with c.read():
+                    pass
+        else:
+            time.sleep(0.05)
+            t = time.time()
+            with c.write():
+                pass
+            elapsed = time.time() - t
+        c._comm.Barrier()
+        if rank != 0:
+            self.assertLess(
+                elapsed,
+                1.0,
+                "Competing write stalled after rank 0 unwound nested reads "
+                "inside a write: the master's reader count is over-released.",
+            )
+
+    @_multi_rank
+    def test_write_inside_read_blocks_competing_writes(self):
+        """A write nested inside an outer read must hold the writer-mutex for
+        its full duration. If promotion does not happen, the writer-mutex spin
+        on the master's count would never succeed (this rank's outer read keeps
+        the count above zero), so the test would either deadlock or, if the
+        promotion is wrong in the other direction, competing writers would slip
+        in before the inner write's sleep completes."""
+        c = self.c
+        elapsed = None
+        if rank == 0:
+            with c.read():
+                with c.write():
+                    time.sleep(0.3)
+        else:
+            time.sleep(0.05)
+            t = time.time()
+            with c.write():
+                pass
+            elapsed = time.time() - t
+        c._comm.Barrier()
+        if rank != 0:
+            self.assertGreater(
+                elapsed,
+                0.2,
+                "Competing write acquired the writer-mutex before the inner "
+                "write inside an outer read completed: promotion did not hold "
+                "the writer-mutex exclusively.",
+            )
+
+    @_multi_rank
+    def test_write_inside_read_restores_reader_after_inner_write_exits(self):
+        """After a promoted write inside an outer read exits, this rank must be
+        re-registered as a reader so the outer read still blocks other writers
+        for the rest of its duration."""
+        c = self.c
+        elapsed = None
+        if rank == 0:
+            with c.read():
+                with c.write():
+                    pass
+                time.sleep(0.3)
+        else:
+            time.sleep(0.05)
+            t = time.time()
+            with c.write():
+                pass
+            elapsed = time.time() - t
+        c._comm.Barrier()
+        if rank != 0:
+            self.assertGreater(
+                elapsed,
+                0.2,
+                "Competing write acquired during the outer read's remaining "
+                "hold: the inner write did not re-register this rank as a "
+                "reader on exit.",
+            )
+
+    @_multi_rank
+    def test_alternating_nested_patterns_under_contention(self):
+        """Cycle through every nested pattern. If any combination corrupts the
+        master's count or orphans the writer-mutex, the post-cycle acquires
+        from other ranks stall instead of completing promptly."""
+        c = self.c
+        elapsed = None
+        if rank == 0:
+            with c.read():
+                with c.read():
+                    pass
+            with c.write():
+                with c.write():
+                    pass
+            with c.write():
+                with c.read():
+                    pass
+            with c.read():
+                with c.write():
+                    pass
+            with c.write():
+                with c.read():
+                    with c.write():
+                        pass
+        else:
+            time.sleep(0.2)
+            t = time.time()
+            with c.write():
+                pass
+            with c.read():
+                pass
+            elapsed = time.time() - t
+        c._comm.Barrier()
+        if rank != 0:
+            self.assertLess(
+                elapsed,
+                1.0,
+                "Acquisitions after the nested-pattern cycle stalled: master "
+                "state is corrupted.",
+            )
+
 
 # ---------------------------------------------------------------------------
 # Stress tests

--- a/tests/test_progress_starvation.py
+++ b/tests/test_progress_starvation.py
@@ -1,0 +1,111 @@
+"""
+Regression test for MPI passive-target progress starvation.
+
+All lock state lives on the master and the master runs a progress pump, so
+acquiring or releasing a lock only needs the master to make MPI progress, never
+the other ranks. When ranks spend long stretches in non-MPI work between lock
+operations, lock acquisition must therefore still complete promptly.
+
+A design where a writer polls every rank's read flag (``Flush_all`` over all
+ranks) instead stalls until the compute-bound ranks next re-enter MPI, so its
+acquisition time scales with the off-MPI compute. These tests pin acquisition
+time well below the compute window, so they fail on such a design and pass on the
+centralized-master one.
+
+Run with:
+    mpiexec --oversubscribe -n 4 python -m unittest tests/test_progress_starvation.py
+"""
+
+import time
+import unittest
+
+import mpi4py.MPI as mpi
+
+from mpilock import sync
+
+rank = mpi.COMM_WORLD.Get_rank()
+size = mpi.COMM_WORLD.Get_size()
+
+
+def _busy_until(t_end):
+    # Pure-Python busy work that makes no MPI calls, so it does not service the
+    # progress engine. This is what starves a design that needs every rank to poll.
+    x = 0
+    while time.time() < t_end:
+        for _ in range(50000):
+            x += 1
+    return x
+
+
+class TestProgressStarvation(unittest.TestCase):
+    def setUp(self):
+        self.c = sync()
+        self.c._comm.Barrier()
+
+    def tearDown(self):
+        self.c.close()
+        self.c._comm.Barrier()
+
+    @unittest.skipIf(size < 3, "needs >=3 ranks: a master, a prober, and a busy rank")
+    def test_writer_not_starved_by_busy_ranks(self):
+        """A writer must acquire promptly even while other ranks sit in long non-MPI
+        compute. Its acquisition may only depend on the master, not on the busy ranks."""
+        c = self.c
+        duration = 2.0
+        c._comm.Barrier()
+        t_end = time.time() + duration
+        max_acq = 0.0
+        if rank == 0:
+            # Master stays responsive (inside MPI) for the duration.
+            while time.time() < t_end:
+                mpi.COMM_WORLD.Iprobe(mpi.ANY_SOURCE, mpi.ANY_TAG)
+                time.sleep(0.001)
+        elif rank == 1:
+            # Prober repeatedly acquires the write lock and records the worst acquire.
+            while time.time() < t_end:
+                t = time.perf_counter()
+                with c.write():
+                    pass
+                max_acq = max(max_acq, time.perf_counter() - t)
+        else:
+            # Busy ranks: a long stretch of non-MPI compute, no lock, no MPI calls.
+            _busy_until(t_end)
+        global_max = c._comm.allreduce(max_acq, op=mpi.MAX)
+        c._comm.Barrier()
+        self.assertLess(
+            global_max,
+            0.5,
+            f"Writer acquisition starved by compute-bound ranks "
+            f"(worst acquire {global_max:.2f}s over a {duration}s window): acquisition "
+            f"is waiting on busy workers instead of only the master.",
+        )
+
+    @unittest.skipIf(size < 2, "requires at least 2 MPI ranks")
+    def test_acquisition_bounded_under_offmpi_compute(self):
+        """With every rank doing a chunk of non-MPI compute between lock operations,
+        acquisition must stay far below the compute-chunk duration."""
+        c = self.c
+        compute_s = 0.5
+        iters = 6
+        is_writer = rank % 4 == 0
+        max_acq = 0.0
+        c._comm.Barrier()
+        for _ in range(iters):
+            end = time.time() + compute_s
+            _busy_until(end)  # spend time outside MPI, like the bender does
+            t = time.perf_counter()
+            if is_writer:
+                with c.write():
+                    pass
+            else:
+                with c.read():
+                    pass
+            max_acq = max(max_acq, time.perf_counter() - t)
+        global_max = c._comm.allreduce(max_acq, op=mpi.MAX)
+        c._comm.Barrier()
+        self.assertLess(
+            global_max,
+            compute_s * 0.5,
+            f"Lock acquisition scaled with off-MPI compute "
+            f"(worst acquire {global_max:.2f}s, compute chunk {compute_s}s).",
+        )

--- a/tests/test_progress_starvation.py
+++ b/tests/test_progress_starvation.py
@@ -12,10 +12,25 @@ acquisition time scales with the off-MPI compute. These tests pin acquisition
 time well below the compute window, so they fail on such a design and pass on the
 centralized-master one.
 
-Run with:
+The stall only manifests on an MPI setup where passive-target RMA depends on the
+target making progress (network RMA, multi-node, no async progress thread; e.g.
+CINECA g100). On a single-node, shared-memory MPI it does not appear, so these
+tests pass on old and new code alike there. To reproduce it on a single node with
+OpenMPI, force RMA over point-to-point (which needs target progress) and a thread
+level it supports:
+
+    OMPI_MCA_osc=pt2pt MPI4PY_RC_THREAD_LEVEL=single MPILOCK_PUMP=0 \\
+        mpiexec --oversubscribe -n 4 python -m unittest tests/test_progress_starvation.py
+
+Under that env the writer test fails on the old design and passes on the new one
+(the master stays responsive, so centralizing state on it is enough). The pump
+test needs MPI_THREAD_MULTIPLE (which pt2pt lacks), so it is skipped there.
+
+Run normally with:
     mpiexec --oversubscribe -n 4 python -m unittest tests/test_progress_starvation.py
 """
 
+import os
 import time
 import unittest
 
@@ -25,6 +40,12 @@ from mpilock import sync
 
 rank = mpi.COMM_WORLD.Get_rank()
 size = mpi.COMM_WORLD.Get_size()
+
+# The pump-dependent test only makes sense where the progress pump can actually run.
+_pump_capable = (
+    mpi.Query_thread() == mpi.THREAD_MULTIPLE
+    and os.environ.get("MPILOCK_PUMP", "1") != "0"
+)
 
 
 def _busy_until(t_end):
@@ -81,9 +102,13 @@ class TestProgressStarvation(unittest.TestCase):
         )
 
     @unittest.skipIf(size < 2, "requires at least 2 MPI ranks")
+    @unittest.skipUnless(
+        _pump_capable, "needs the progress pump (MPI_THREAD_MULTIPLE and MPILOCK_PUMP)"
+    )
     def test_acquisition_bounded_under_offmpi_compute(self):
         """With every rank doing a chunk of non-MPI compute between lock operations,
-        acquisition must stay far below the compute-chunk duration."""
+        acquisition must stay far below the compute-chunk duration. Unlike the writer
+        test, no rank stays responsive here, so this relies on the master's pump."""
         c = self.c
         compute_s = 0.5
         iters = 6

--- a/tests/test_progress_starvation.py
+++ b/tests/test_progress_starvation.py
@@ -8,9 +8,9 @@ operations, lock acquisition must therefore still complete promptly.
 
 A design where a writer polls every rank's read flag (``Flush_all`` over all
 ranks) instead stalls until the compute-bound ranks next re-enter MPI, so its
-acquisition time scales with the off-MPI compute. These tests pin acquisition
-time well below the compute window, so they fail on such a design and pass on the
-centralized-master one.
+acquisition time scales with the off-MPI compute. These tests bound acquisition
+time far below the seconds-to-tens-of-seconds stall such a design exhibits at
+scale, so they fail on it and pass on the centralized-master one.
 
 The stall only manifests on an MPI setup where passive-target RMA depends on the
 target making progress (network RMA, multi-node, no async progress thread; e.g.
@@ -128,9 +128,16 @@ class TestProgressStarvation(unittest.TestCase):
             max_acq = max(max_acq, time.perf_counter() - t)
         global_max = c._comm.allreduce(max_acq, op=mpi.MAX)
         c._comm.Barrier()
+        # A starved design (per-rank polling, or no/weak pump) makes acquisition scale
+        # with the off-MPI compute and the rank count: seconds to tens of seconds on
+        # g100. The centralized master with a real-RMA progress pump keeps it well under
+        # a second even with the master itself compute-bound (its pump thread fights the
+        # GIL), so a sub-second bound passes the fix yet fails every starved variant.
+        bound = 1.0
         self.assertLess(
             global_max,
-            compute_s * 0.5,
-            f"Lock acquisition scaled with off-MPI compute "
-            f"(worst acquire {global_max:.2f}s, compute chunk {compute_s}s).",
+            bound,
+            f"Lock acquisition is not bounded under off-MPI compute "
+            f"(worst acquire {global_max:.2f}s, bound {bound}s, compute chunk "
+            f"{compute_s}s): the master's progress pump is not clearing acquisitions.",
         )


### PR DESCRIPTION
## Problem

Under MPI, passive-target RMA only makes progress while the *target* rank is inside MPI. The write lock polled **every** rank's read flag (`Lock_all` + per-rank `Get` + `Flush_all`), so a write acquisition could only complete once every rank next re-entered MPI. When ranks spend long stretches in non-MPI work between lock operations (heavy compute, e.g. morphology generation in a BSB run), their windows are not serviced, so other ranks' lock acquisitions stall until those ranks next touch MPI.

The stall scales with rank count and is severe across nodes. It was observed on CINECA g100: at 48 ranks, lock acquisition grew from sub-second to tens of seconds, and a single long compute on one rank stalled every other rank's acquisition for its full duration (read as a multi-minute "hang").

## Fix

Centralize all lock state on the master so every acquire and release only ever needs cooperation from the master, never from the (possibly busy) workers:

- A single reader count lives in the master's window.
- Readers register by atomically incrementing that count under the writer-mutex window (so a held or pending write still blocks new reads), and release it with a **lockless atomic decrement** (so a writer can hold the mutex and still observe the count drain).
- The writer takes the writer-mutex window exclusively, then reads **only the master's count** and spins until it reaches zero. No more `Lock_all` / per-rank `Flush_all`.

Run **one** daemon progress thread, on the master only, that keeps the MPI progress engine turning so acquisitions issued by other ranks complete even while the master's main thread is busy. The pump performs a **real RMA cycle** (`Lock`/`Get`/`Flush`/`Unlock`) on a private per-controller window each tick. A bare `Iprobe` was tried first but drives the progress engine too weakly to clear many concurrent acquisitions (see Validation). Toggle with `sync(pump=True, pump_interval=1e-4)`.

Re-entrant locks stay local (only the outermost acquire/release touches the master).

## API

Backward compatible. `sync()` / `WindowController(...)` gain optional `pump` and `pump_interval` arguments. Existing `read()` / `write()` / `single_write()` / `Fence` semantics are unchanged (writes exclusive, reads concurrent with reads, reads blocked while a write is held or requested).

## Requirements

The progress pump calls MPI from a thread, so the runtime must be initialized with `MPI_THREAD_MULTIPLE`. Set `pump=False` to opt out.

## Validation (CINECA g100, 48 ranks, single node)

Worst-case lock acquisition while workers spend 0.5s in non-MPI compute between locks, so only the master can service their acquisitions:

| scenario | old per-rank design | Iprobe pump | real-RMA pump |
|---|---|---|---|
| master free (the BSB scheduler case) | ~25s | 5.19s | **0.020s** |
| master also compute-bound | ~25s | 2.02s | **0.365s** |
| no pump (control) | n/a | 14.52s | 14.52s |

The Iprobe pump only partially mitigated the stall: even with the master fully free it left acquisitions at ~5s under 47 concurrent acquirers. The real-RMA pump drives the progress engine hard enough to clear them in ~20ms.

## Tests

Adds `tests/test_progress_starvation.py`:

- **Writer test:** a prober must acquire the write lock promptly while other ranks sit in long non-MPI compute. Passes on the centralized master, fails on per-rank polling.
- **Bounded test:** with every rank computing between locks, acquisition must stay under 1.0s. Fails the per-rank design (~25s), a missing pump (~14.5s), and the weak Iprobe pump (~2.0s); passes the real-RMA pump.

The stall only manifests where passive-target RMA depends on the target making progress (network RMA, multi-node, no async progress thread; e.g. g100). On single-node shared-memory MPI it does not appear, so the tests pass on old and new code alike there. CI forces it on a single node by routing RMA over point-to-point (`OMPI_MCA_osc=pt2pt`) at a thread level it supports, with the pump disabled, so the writer test reproduces the stall and gates the centralized-master design.

Full suite passes locally under `mpiexec --oversubscribe -n 4`.
